### PR TITLE
Fix karma-sauce-example | SUP-123

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ node_js:
 - '0.10'
 env:
   global:
-  - secure: e+4y7ABujyG/ojYqTOv46oe20pLsPaZ5nuy36Lr53Q51kiELhIBe8VTDcZvYaL6IzC1tWOQ6c4drTpPDxYT8/10Jdn4+gtSTSMMBAwY+GTkUH/tYZZZCR8yDg2iQu5i3gRAdJWLQZiTheIu99XNbj9yMgvqg+X1c21jVSWZ+Fdg=
-  - secure: Ra6z8HWzWYv/rW8hAfEEq144njY7vagP+6hjoGwgRz+xYkN3Kv4ZcHvM2RVOtXV7ofbZt/ZZU2jx1pUmS8gqk2rTnLq01A//P8mxrFDRDZk8MiIXkXAht1WfWUiyGIeHF3HvHiZ9ZqxXSVkouKdgb6t+479LdX0ydsnHMw7dOd4=
-notifications:
+    - secure: Z6YtNiNRMIZ4dXfgXNg/C30YQ8MKI+nXh6lCOjp02cBRbyX31xl8y1XsiuV5/QSDHmWW4JLATmIrO5uiJLz2rAMjmf6+Wdn/0icswzAhYnNgrR3BtUgx3YGG7GZk6hYR4T5rbv6RnpQDgiHR3NE2ff07r1MpBU7EheqaxylvfPw=
+    - secure: aMcFhneV8563uDQ+lh13foeI0OBJQE53htdbXkcq9AnNjK8u5EoK+MgU248Hcw7ohcoxw35CJ2rsWhNWcJ0hJtg6+PuTbjb8xOg/3pMza9/8VGpyhM0QGXNMV5b85HdzqNJXaTXr+pKsrZQDNbtCHGNaxVVGPlno551KRqu8X+U=
   email: false
 before_script: npm install -g karma-cli

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
     'SL_Firefox': {
       base: 'SauceLabs',
       browserName: 'internet explorer',
-      version: '9'
+      version: '10'
     }
   };
 

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -19,10 +19,14 @@ module.exports = function(config) {
       base: 'SauceLabs',
       browserName: 'chrome'
     },
-    'SL_Firefox': {
+    'SL_InternetExplorer': {
       base: 'SauceLabs',
       browserName: 'internet explorer',
       version: '10'
+    }
+    'SL_FireFox': {
+      base: 'SauceLabs',
+      browserName: 'firefox',
     }
   };
 

--- a/karma.conf-ci.js
+++ b/karma.conf-ci.js
@@ -23,7 +23,7 @@ module.exports = function(config) {
       base: 'SauceLabs',
       browserName: 'internet explorer',
       version: '10'
-    }
+    },
     'SL_FireFox': {
       base: 'SauceLabs',
       browserName: 'firefox',


### PR DESCRIPTION
**Ticket**: [SUP-123](https://saucedev.atlassian.net/browse/SUP-123)

@sourishkrout mind reviewing this?

#### Problem

```IE9 fails in this example;
IE 9.0.0 (Windows 7) updateAppState should push a new state into the browser history FAILED
	TypeError: Object doesn't support property or method 'pushState'
IE 9.0.0 (Windows 7) updateAppState should push a new state into the browser history FAILED
	TypeError: Object doesn't support property or method 'pushState'
IE 9.0.0 (Windows 7): Executed 3 of 3 (1 FAILED) (0.096 secs / 0.001 secs)```

Running this fails on IE with ^^

#### Solution

Change to IE10 seems the easiest way to make this example a working demonstration of Sauce Labs and Karma. Also moved the user karma-sauce-example to be a sub for 'colinpade' and setup the .travis.yml to use it

#### Comments

I felt making this work in IE9 not to be a fruitful effort when changing to IE10 works.

#### Possible improvements

Make work in IE9?

#### Checklist

- [ ] Is there any cruft that should be removed along with this code change? [comment if yes]
- [ ] Is that code change resulting in any SQL query changes to the database? [comment if yes]
- [ ] Have you inspected queries that are run on the DB by the changed code? [comment if yes]
- [ ] Is that code change resulting in any performance changes to the application)? [comment if yes]